### PR TITLE
rename last bits from bmailer to ckmailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bmailer
+# ckmailer
 self-hosted software for newsletters
 
 There are multiple channels. Subscribers are identified by their email
@@ -15,7 +15,7 @@ unsubscribe link.
 
 # Status
 "works for me", there is no real documentation, you'll likely struggle to
-unststand how this works for now.
+understand how this works for now.
 
 # Requirements
 

--- a/ckmailer.cc
+++ b/ckmailer.cc
@@ -103,7 +103,7 @@ string markdownToWeb(const std::string& input, const std::string& title)
 int main(int argc, char** argv)
 {
   signal(SIGPIPE, SIG_IGN); // every TCP application needs this
-  argparse::ArgumentParser args("bmailer", "0.0");
+  argparse::ArgumentParser args("ckmailer", "0.0");
   map<string, string> settings;
   args.add_argument("--smtp-server").help("IP address of SMTP smart host. If empty, no mail will get sent").default_value("").store_into(settings["smtp-server"]);
   args.add_argument("--imap-server").help("IMAP server to query").default_value("").store_into(settings["imap-server"]);
@@ -365,7 +365,7 @@ int main(int argc, char** argv)
 		textmsg,
 		htmlmsg,
 		"",
-		"bmailer+"+getLargeId()+"@hubertnet.nl", att);
+		"ckmailer+"+getLargeId()+"@hubertnet.nl", att);
     }
     else if(cmds[0]=="launch") {
       // launch m1 c2 "Welkom"
@@ -480,7 +480,7 @@ int main(int argc, char** argv)
 	cout<<"Sending to "<< eget(q, "destination") <<endl;
 
 	vector<pair<string,string>> headers = {
-	  {"List-Unsubscribe", "<https://berthub.eu/ckmailer/unsubscribe/"+eget(q, "userId")+"/"+eget(q, "channelId")+">, <mailto:bmailer+"+eget(q, "queueId")+"@hubertnet.nl?subject="+eget(q, "userId")+"/"+eget(q, "channelId")+">"},
+	  {"List-Unsubscribe", "<https://berthub.eu/ckmailer/unsubscribe/"+eget(q, "userId")+"/"+eget(q, "channelId")+">, <mailto:ckmailer+"+eget(q, "queueId")+"@hubertnet.nl?subject="+eget(q, "userId")+"/"+eget(q, "channelId")+">"},
 	  {"List-Unsubscribe-Post", "List-Unsubscribe=One-Click"},
 	  {"List-ID", eget(q, "channelName") + " <"+eget(q, "channelId")+">"}
 	};
@@ -493,7 +493,7 @@ int main(int argc, char** argv)
 		  textmsg,
 		  htmlmsg,
 		  "",
-		  "bmailer+"+ eget(q, "queueId") +"@hubertnet.nl", att, headers);
+		  "ckmailer+"+ eget(q, "queueId") +"@hubertnet.nl", att, headers);
 
 	db.queryT("update queue set sent=1 where id=?", {eget(q, "queueId")});
 	sleep(1);
@@ -541,7 +541,7 @@ int main(int argc, char** argv)
       }
     }
     if (imap_command["--active"] == true && !handled.empty()) {
-      imapMove(ComboAddress(settings["imap-server"], 993), "bmailer", settings["imap-password"], handled);
+      imapMove(ComboAddress(settings["imap-server"], 993), "ckmailer", settings["imap-password"], handled);
     }
 
   }


### PR DESCRIPTION
the code is a little bit schizophrenic about the name of the project: apparently it got renamed from bmailer to ckmailer. The only downside of correcting it like this is that it seems that you'd need to also make a similar rename on your mail server

I was interested in the software because I started a local Python user group and got interested into self-hosting and was considering a mailing list

you wrote that writing your own mailsoftware is 'not some kind of crazy flex' but I guess it's OK to admit that it actually kinda _is_... 